### PR TITLE
Adding asymmetric padding to support tiny yolo networks

### DIFF
--- a/sources/gst-yoloplugin/yoloplugin_lib/trt_utils.cpp
+++ b/sources/gst-yoloplugin/yoloplugin_lib/trt_utils.cpp
@@ -326,6 +326,19 @@ int getNumChannels(nvinfer1::ITensor* t)
     return d.d[0];
 }
 
+nvinfer1::ILayer* netAddPadding1(int layerIdx, std::map<std::string, std::string>& block,
+                                 nvinfer1::ITensor* input, nvinfer1::INetworkDefinition* network)
+{
+    // addPadding performs zero-padding. Actually it would be better to add -std::numeric_limits<float>::max()
+    // for use in combination with the maxpool layer.
+    nvinfer1::IPaddingLayer* pad = network->addPadding(*input, nvinfer1::DimsHW{0, 0}, nvinfer1::DimsHW{1, 1});
+    assert(pad);
+    std::string paddingLayerName = "padding_" + std::to_string(layerIdx);
+    pad->setName(paddingLayerName.c_str());
+
+    return pad;
+}
+
 nvinfer1::ILayer* netAddMaxpool(int layerIdx, std::map<std::string, std::string>& block,
                                 nvinfer1::ITensor* input, nvinfer1::INetworkDefinition* network)
 {

--- a/sources/gst-yoloplugin/yoloplugin_lib/trt_utils.h
+++ b/sources/gst-yoloplugin/yoloplugin_lib/trt_utils.h
@@ -95,6 +95,8 @@ void displayDimType(const nvinfer1::Dims d);
 int getNumChannels(nvinfer1::ITensor* t);
 
 // Helper functions to create yolo engine
+nvinfer1::ILayer* netAddPadding1(int layerIdx, std::map<std::string, std::string>& block,
+                                 nvinfer1::ITensor* input, nvinfer1::INetworkDefinition* network);
 nvinfer1::ILayer* netAddMaxpool(int layerIdx, std::map<std::string, std::string>& block,
                                 nvinfer1::ITensor* input, nvinfer1::INetworkDefinition* network);
 nvinfer1::ILayer* netAddConvLinear(int layerIdx, std::map<std::string, std::string>& block,


### PR DESCRIPTION
I tried to run a tiny yolov2 network using this code but it did not work. I noticed that the dimensions of the layers following a maxpool with stride=1 were different compared to the same network ran in darknet.

I found an explanation on [this link](https://ai.stackexchange.com/questions/4199/max-pooling-size-2-stride-1-outputs-same-size) and when playing with the UFF parser to try to get a tiny yolov2 network working with TensorRT I saw a message about asymmetric padding in the log outputs. I guess this pull request implements a similar solution.
