### PR TITLE
Fix trt-yolo-app code to be on separate lines

### DIFF
--- a/yolo/README.md
+++ b/yolo/README.md
@@ -64,7 +64,7 @@ The trt-yolo-app located at `apps/trt-yolo` is a sample standalone app, which ca
 
 `$ cd apps/trt-yolo`    
 `$ mkdir build && cd build`   
-`$ cmake -D CMAKE_BUILD_TYPE=Release ..`
+`$ cmake -D CMAKE_BUILD_TYPE=Release ..`    
 `$ make && sudo make install`   
 `$ cd ../../../`   
 `$ trt-yolo-app --flagfile=/path/to/config-file.txt`


### PR DESCRIPTION
Before this change, these two lines in trt-yolo-app instructions were rendered on the same line like so:

`$ cmake -D CMAKE_BUILD_TYPE=Release ..` `$ make && sudo make install`

This fix makes it separate lines like so

`$ cmake -D CMAKE_BUILD_TYPE=Release ..` 
`$ make && sudo make install`
